### PR TITLE
Update MACD ADX backtest and add sweep script

### DIFF
--- a/research/backtest_macd_adx.py
+++ b/research/backtest_macd_adx.py
@@ -1,41 +1,129 @@
-# Quick sanity-check backtest using Backtesting.py
-from backtesting import Backtest, Strategy
-from backtesting.lib import crossover
-from backtesting.test import GOOG
+import os
+import time
+import math
+import ccxt
+import numpy as np
 import pandas as pd
-import pandas_ta as ta
 
-# NOTE: Replace GOOG with real crypto candles loaded via pandas
-data = GOOG.copy()
-data.rename(columns={'Close':'close','High':'high','Low':'low','Open':'open','Volume':'volume'}, inplace=True)
+# Choose your indicator lib
+USE_TALIB = False  # set True if you installed TA-Lib
+if USE_TALIB:
+    import talib
+else:
+    import pandas_ta as ta
 
+from backtesting import Backtest, Strategy
+
+# -----------------------------
+# 1) DATA LOADER (CCXT, BTC/USDT, 1h)
+# -----------------------------
+def load_ccxt_ohlcv(symbol="BTC/USDT", timeframe="1h", limit=2000, exchange="binance"):
+    if exchange.lower() == "binance":
+        ex = ccxt.binance({"enableRateLimit": True, "options": {"defaultType": "spot"}})
+    elif exchange.lower() == "coinbase":
+        # Coinbase Advanced (usable in the US)
+        ex = ccxt.coinbaseadvanced({"enableRateLimit": True})
+    else:
+        raise ValueError("Unsupported exchange")
+
+    # Fetch in one call (simple). If you want more history, paginate here.
+    raw = ex.fetch_ohlcv(symbol, timeframe=timeframe, limit=limit)
+    df = pd.DataFrame(raw, columns=["Date", "Open", "High", "Low", "Close", "Volume"])
+    df["Date"] = pd.to_datetime(df["Date"], unit="ms", utc=True)
+    df.set_index("Date", inplace=True)
+    # Backtesting.py expects capitalized column names
+    return df[["Open", "High", "Low", "Close", "Volume"]].astype(float)
+
+
+# -----------------------------
+# 2) STRATEGY: MACD + ADX + VOL TARGET
+# -----------------------------
 class MACD_ADX_Strategy(Strategy):
+    # MACD params
     macd_fast = 12
     macd_slow = 26
     macd_signal = 9
+    # ADX params
     adx_len = 14
     adx_threshold = 25
+    # Vol-target params (heuristic for 1h data)
+    vol_lb = 20             # lookback (bars) for realized vol
+    target_vol = 0.02       # target (per-bar-ish proxy) — will tune in sweep
+    size_min = 0.0
+    size_max = 1.0
 
     def init(self):
         price = self.data.Close
-        macd = ta.macd(price, fast=self.macd_fast, slow=self.macd_slow, signal=self.macd_signal)
-        self.macd_hist = self.I(lambda: macd['MACDh_12_26_9'].values, name='macd_hist')
-        adx = ta.adx(high=self.data.High, low=self.data.Low, close=price, length=self.adx_len)
-        self.adx = self.I(lambda: adx['ADX_14'].values, name='adx')
+
+        if USE_TALIB:
+            macd, macdsignal, macdhist = talib.MACD(
+                price.values, fastperiod=self.macd_fast, slowperiod=self.macd_slow, signalperiod=self.macd_signal
+            )
+            self.macd_hist = self.I(lambda: macdhist, name="macd_hist")
+            adx = talib.ADX(self.data.High.values, self.data.Low.values, price.values, timeperiod=self.adx_len)
+            self.adx = self.I(lambda: adx, name="adx")
+        else:
+            macd_df = ta.macd(price, fast=self.macd_fast, slow=self.macd_slow, signal=self.macd_signal)
+            adx_df = ta.adx(high=self.data.High, low=self.data.Low, close=price, length=self.adx_len)
+            self.macd_hist = self.I(lambda: macd_df.iloc[:, 2].values, name="macd_hist")  # MACDh
+            self.adx = self.I(lambda: adx_df.iloc[:, 0].values, name="adx")  # ADX
+
+        # Volatility estimate (realized)
+        rets = price.pct_change().fillna(0.0)
+        self.realized_vol = self.I(lambda: rets.rolling(self.vol_lb).std().values, name="realized_vol")
+
+    def position_size_scale(self):
+        vol = self.realized_vol[-1]
+        if vol is None or np.isnan(vol) or vol <= 0:
+            return 0.0
+        scale = float(self.target_vol / vol)
+        return float(np.clip(scale, self.size_min, self.size_max))
 
     def next(self):
-        # Filter for trend strength
+        # (2) ADX filter for trend strength
         if self.adx[-1] <= self.adx_threshold:
             return
-        # MACD histogram cross
-        if self.macd_hist[-1] > 0 and self.macd_hist[-2] <= 0:
-            self.position.close()
-            self.buy()
-        elif self.macd_hist[-1] < 0 and self.macd_hist[-2] >= 0:
-            self.position.close()
-            self.sell()
 
-bt = Backtest(data, MACD_ADX_Strategy, cash=10000, commission=.001, trade_on_close=True)
-stats = bt.run()
-print(stats)
-# bt.plot()  # Uncomment to visualize
+        # MACD histogram zero-cross for direction
+        crossed_up = self.macd_hist[-1] > 0 and self.macd_hist[-2] <= 0
+        crossed_down = self.macd_hist[-1] < 0 and self.macd_hist[-2] >= 0
+
+        size_scale = self.position_size_scale()
+        if size_scale <= 0:
+            return
+
+        if crossed_up:
+            self.position.close()
+            self.buy(size=size_scale)
+        elif crossed_down:
+            self.position.close()
+            self.sell(size=size_scale)
+
+
+def run_backtest(
+    symbol="BTC/USDT",
+    timeframe="1h",
+    exchange="binance",
+    commission=0.001,   # (2) ~0.10% taker fee
+):
+    df = load_ccxt_ohlcv(symbol=symbol, timeframe=timeframe, limit=2000, exchange=exchange)
+    print("Data shape:", df.shape)
+    print("Date range:", df.index.min(), "to", df.index.max())
+
+    bt = Backtest(
+        df,
+        MACD_ADX_Strategy,
+        cash=10_000,                # backtest notional
+        commission=commission,      # fees matter!
+        trade_on_close=True,
+        exclusive_orders=True
+    )
+    stats = bt.run()
+    print("\n" + "="*50 + "\nBACKTEST RESULTS\n" + "="*50)
+    print(stats)
+    # bt.plot(open_browser=False)  # uncomment to visualize when running locally
+    return stats
+
+
+if __name__ == "__main__":
+    run_backtest(symbol="BTC/USDT", timeframe="1h", exchange="binance", commission=0.0012)

--- a/research/sweep_macd_adx.py
+++ b/research/sweep_macd_adx.py
@@ -1,0 +1,141 @@
+import itertools
+import numpy as np
+import pandas as pd
+import ccxt
+from backtesting import Backtest, Strategy
+import pandas_ta as ta
+
+USE_TALIB = False
+if USE_TALIB:
+    import talib
+
+def load_df(symbol="BTC/USDT", timeframe="1h", limit=3000, exchange="binance"):
+    if exchange.lower() == "binance":
+        ex = ccxt.binance({"enableRateLimit": True, "options": {"defaultType": "spot"}})
+    else:
+        ex = ccxt.coinbaseadvanced({"enableRateLimit": True})
+    raw = ex.fetch_ohlcv(symbol, timeframe=timeframe, limit=limit)
+    df = pd.DataFrame(raw, columns=["Date","Open","High","Low","Close","Volume"])
+    df["Date"] = pd.to_datetime(df["Date"], unit="ms", utc=True)
+    df.set_index("Date", inplace=True)
+    return df.astype(float)
+
+class Strat(Strategy):
+    macd_fast = 12
+    macd_slow = 26
+    macd_signal = 9
+    adx_len = 14
+    adx_threshold = 25
+    vol_lb = 20
+    target_vol = 0.02
+    size_min = 0.0
+    size_max = 1.0
+
+    def init(self):
+        price = self.data.Close
+        if USE_TALIB:
+            macd, macdsignal, macdhist = talib.MACD(
+                price.values, fastperiod=self.macd_fast, slowperiod=self.macd_slow, signalperiod=self.macd_signal
+            )
+            self.macd_hist = self.I(lambda: macdhist, name="macd_hist")
+            adx = talib.ADX(self.data.High.values, self.data.Low.values, price.values, timeperiod=self.adx_len)
+            self.adx = self.I(lambda: adx, name="adx")
+        else:
+            macd_df = ta.macd(price, fast=self.macd_fast, slow=self.macd_slow, signal=self.macd_signal)
+            adx_df = ta.adx(high=self.data.High, low=self.data.Low, close=price, length=self.adx_len)
+            self.macd_hist = self.I(lambda: macd_df.iloc[:,2].values, name="macd_hist")
+            self.adx = self.I(lambda: adx_df.iloc[:,0].values, name="adx")
+
+        rets = price.pct_change().fillna(0.0)
+        self.realized_vol = self.I(lambda: rets.rolling(self.vol_lb).std().values, name="realized_vol")
+
+    def position_size_scale(self):
+        vol = self.realized_vol[-1]
+        if vol is None or np.isnan(vol) or vol <= 0:
+            return 0.0
+        return float(np.clip(self.target_vol / vol, self.size_min, self.size_max))
+
+    def next(self):
+        if self.adx[-1] <= self.adx_threshold:
+            return
+        size_scale = self.position_size_scale()
+        if size_scale <= 0:
+            return
+        crossed_up = self.macd_hist[-1] > 0 and self.macd_hist[-2] <= 0
+        crossed_down = self.macd_hist[-1] < 0 and self.macd_hist[-2] >= 0
+        if crossed_up:
+            self.position.close()
+            self.buy(size=size_scale)
+        elif crossed_down:
+            self.position.close()
+            self.sell(size=size_scale)
+
+def run_split_backtest(df, params, commission=0.0012):
+    k = int(len(df) * 0.7)
+    df_is, df_oos = df.iloc[:k], df.iloc[k:]
+
+    def run(df_part):
+        bt = Backtest(df_part, Strat, cash=10_000, commission=commission, trade_on_close=True, exclusive_orders=True)
+        return bt.run(**params)
+
+    stats_is = run(df_is)
+    stats_oos = run(df_oos)
+    return stats_is, stats_oos
+
+def main():
+    grids = {
+        "timeframe": ["1h", "4h"],
+        "macd_fast": [8, 12],
+        "macd_slow": [24, 26],
+        "macd_signal": [9],
+        "adx_threshold": [20, 25, 30],
+        "vol_lb": [20, 30],
+        "target_vol": [0.015, 0.02],
+    }
+
+    combos = list(itertools.product(
+        grids["timeframe"], grids["macd_fast"], grids["macd_slow"],
+        grids["macd_signal"], grids["adx_threshold"], grids["vol_lb"], grids["target_vol"]
+    ))
+
+    rows = []
+    for (tf, mf, ms, sig, adx_thr, vol_lb, tgt_vol) in combos:
+        df = load_df("BTC/USDT", timeframe=tf, limit=2500, exchange="binance")
+        # patch params into class via **kwargs
+        params = dict(
+            macd_fast=mf, macd_slow=ms, macd_signal=sig,
+            adx_len=14, adx_threshold=adx_thr,
+            vol_lb=vol_lb, target_vol=tgt_vol
+        )
+        is_stats, oos_stats = run_split_backtest(df, params)
+
+        def pick(s):
+            return dict(
+                Return=float(s["Return [%]"]),
+                Sharpe=float(s["Sharpe Ratio"]),
+                MaxDD=float(s["Max. Drawdown [%]"]),
+                Trades=int(s["# Trades"]),
+            )
+
+        rows.append({
+            "tf": tf,
+            "macd": f"{mf}/{ms}/{sig}",
+            "adx_thr": adx_thr,
+            "vol_lb": vol_lb,
+            "tgt_vol": tgt_vol,
+            "IS_Sharpe": pick(is_stats)["Sharpe"],
+            "IS_MaxDD": pick(is_stats)["MaxDD"],
+            "IS_Trades": pick(is_stats)["Trades"],
+            "OOS_Sharpe": pick(oos_stats)["Sharpe"],
+            "OOS_MaxDD": pick(oos_stats)["MaxDD"],
+            "OOS_Trades": pick(oos_stats)["Trades"],
+        })
+        print(f"Done {tf}, MACD {mf}/{ms}/{sig}, ADX>{adx_thr}, vol_lb={vol_lb}, tgt={tgt_vol}")
+
+    out = pd.DataFrame(rows).sort_values(["OOS_Sharpe"], ascending=False)
+    print("\nTOP RESULTS (sorted by OOS Sharpe)\n", out.head(15).to_string(index=False))
+    out.to_csv("research/sweep_results.csv", index=False)
+    print("\nSaved: research/sweep_results.csv")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- replace the MACD + ADX backtest to pull live BTC/USDT candles from CCXT, include commission, and add volatility targeting
- allow toggling between pandas-ta and TA-Lib for indicators
- add a parameter sweep utility that evaluates multiple configurations with an in/out-of-sample split and saves the results

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2c25177fc832ebd7d161fc71b60b5